### PR TITLE
Automatic discovery of `mmdc`

### DIFF
--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -45,13 +45,16 @@
   (let* ((out-file (or (cdr (assoc :file params))
                        (error "mermaid requires a \":file\" header argument")))
          (temp-file (org-babel-temp-file "mermaid-"))
-         (cmd (if (not ob-mermaid-cli-path)
-                  (error "`ob-mermaid-cli-path' is not set")
-                (concat (shell-quote-argument (expand-file-name ob-mermaid-cli-path))
-                        " -i " (org-babel-process-file-name temp-file)
-                        " -o " (org-babel-process-file-name out-file)))))
-    (unless (file-exists-p ob-mermaid-cli-path)
-      (error "could not find mermaid.cli executable at %s" ob-mermaid-cli-path))
+         (mmdc (or ob-mermaid-cli-path
+                   (executable-find "mmdc")
+                   (error "`ob-mermaid-cli-path' is not set and mmdc is not in `exec-path'")))
+         (cmd (concat (shell-quote-argument (expand-file-name mmdc))
+                      " -i " (org-babel-process-file-name temp-file)
+                      " -o " (org-babel-process-file-name out-file))))
+    (unless (file-executable-p mmdc)
+      ;; cannot happen with `executable-find', so we complain about
+      ;; `ob-mermaid-cli-path'
+      (error "Cannot find or execute %s, please check `ob-mermaid-cli-path'" mmdc))
     (with-temp-file temp-file (insert body))
     (message "%s" cmd)
     (org-babel-eval cmd "")


### PR DESCRIPTION
- use `ob-mermaid-cli-path` if set
- otherwise try `(executable-find "mmdc")`
- otherwise error

- also error if `mmdc` is somehow not executable