### PR TITLE
Added missing logic for pupeteer-config-file

### DIFF
--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -69,7 +69,9 @@
 		      (when mermaid-config-file
 			(concat " -c " (org-babel-process-file-name mermaid-config-file)))
 		      (when css-file
-			(concat " -C " (org-babel-process-file-name css-file))))))
+			(concat " -C " (org-babel-process-file-name css-file)))
+                      (when pupeteer-config-file
+                        (concat " -p " (org-babel-process-file-name pupeteer-config-file))))))
     (unless (file-executable-p mmdc)
       ;; cannot happen with `executable-find', so we complain about
       ;; `ob-mermaid-cli-path'


### PR DESCRIPTION
I added what was missing for the :pupeteer-config-file header to work correctly.