### PR TITLE
Add quotes to width and height argument, conforming to CLI tool

### DIFF
--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -63,9 +63,9 @@
 		      (when background-color
 			(concat " -b " background-color))
 		      (when width
-			(concat " -w " width))
+			(format " -w \"%d\"" width))
 		      (when height
-			(concat " -H " height))
+			(format " -H \"%d\"" height))
 		      (when mermaid-config-file
 			(concat " -c " (org-babel-process-file-name mermaid-config-file)))
 		      (when css-file


### PR DESCRIPTION
Surprisingly CLI tool accepts `width` and `height` argument in string form. Instead of writing `:width "1200"`, writing `:width 1200` is more natural. 