### PR TITLE
feat: pipe code through STDIN instead of temp file

### DIFF
--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -90,8 +90,7 @@ For htmlLabels specifically, see URL
                            mmdc-path
                          (error "Found mmdc at %s but it's not executable" mmdc-path))
                      (error "`ob-mermaid-cli-path' is not set and mmdc is not in `exec-path'"))))
-         (cmd (concat "echo " (shell-quote-argument body) " | "
-                      (shell-quote-argument mmdc)
+         (cmd (concat (shell-quote-argument mmdc)
                       " -o " (org-babel-process-file-name out-file)
                       " -i -"
 		      (when theme
@@ -115,7 +114,7 @@ For htmlLabels specifically, see URL
 		      (when cmdline
 			(concat " " cmdline)))))
     (message "%s" cmd)
-    (org-babel-eval cmd "")
+    (org-babel-eval cmd body)
     nil))
 
 (provide 'ob-mermaid)

--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -91,7 +91,7 @@ For htmlLabels specifically, see URL
                          (error "Found mmdc at %s but it's not executable" mmdc-path))
                      (error "`ob-mermaid-cli-path' is not set and mmdc is not in `exec-path'"))))
          (cmd (concat "echo " (shell-quote-argument body) " | "
-                      (shell-quote-argument (expand-file-name mmdc))
+                      (shell-quote-argument mmdc)
                       " -o " (org-babel-process-file-name out-file)
                       " -i -"
 		      (when theme

--- a/ob-mermaid.el
+++ b/ob-mermaid.el
@@ -83,7 +83,6 @@ For htmlLabels specifically, see URL
 	 (puppeteer-config-file (cdr (assoc :puppeteer-config-file params)))
 	 (pdf-fit (assoc :pdf-fit params))
 	 (cmdline (cdr (assoc :cmdline params)))
-         (temp-file (org-babel-temp-file "mermaid-"))
          (mmdc-path (executable-find "mmdc"))
          (mmdc (or ob-mermaid-cli-path
                    (if mmdc-path
@@ -91,9 +90,10 @@ For htmlLabels specifically, see URL
                            mmdc-path
                          (error "Found mmdc at %s but it's not executable" mmdc-path))
                      (error "`ob-mermaid-cli-path' is not set and mmdc is not in `exec-path'"))))
-         (cmd (concat mmdc
-                      " -i " (org-babel-process-file-name temp-file)
+         (cmd (concat "echo " (shell-quote-argument body) " | "
+                      (shell-quote-argument (expand-file-name mmdc))
                       " -o " (org-babel-process-file-name out-file)
+                      " -i -"
 		      (when theme
 			(concat " -t " theme))
 		      (when background-color
@@ -114,7 +114,6 @@ For htmlLabels specifically, see URL
                         (concat " -p " (org-babel-process-file-name puppeteer-config-file)))
 		      (when cmdline
 			(concat " " cmdline)))))
-    (with-temp-file temp-file (insert body))
     (message "%s" cmd)
     (org-babel-eval cmd "")
     nil))

--- a/test-example.org
+++ b/test-example.org
@@ -220,6 +220,21 @@ flowchart LR
 #+RESULTS:
 [[file:test-svg-emacs.svg]]
 
+** STDIN Piping with Special Characters
+
+Tests that STDIN piping handles special shell characters correctly (quotes, ampersands, etc.)
+
+#+begin_src mermaid :file test-stdin-special-chars.png
+flowchart TD
+    A["User's Input"] --> B{"Is it valid?"}
+    B -->|"Yes & proceed"| C["Process $data"]
+    B -->|"No (retry)"| A
+    C --> D["`Done!`"]
+#+end_src
+
+#+RESULTS:
+[[file:test-stdin-special-chars.png]]
+
 * Testing Instructions
 
 1. Place cursor on any code block above


### PR DESCRIPTION
## Summary

- Pipes mermaid code through STDIN (`-i -`) instead of writing to a temp file
- Enables containerized/Docker mermaid-cli installations where temp files aren't accessible inside the container
- Adds test for special shell characters to verify proper escaping

Closes #24

## Credits

Based on PR #25 by @ayorgo. That PR had merge conflicts with recent changes, so this is a fresh implementation rebased on current master with additional fixes:

- Fixed `expand-file-name` bug that broke `executable-find` paths
- Preserved all recent features (default config file, puppeteer typo fix, scale/pdf-fit/cmdline params)
- Added test case for shell special characters

## Docker Usage Example

From issue #24, users can now use a wrapper script like:

```sh
#!/usr/bin/env sh
docker run --rm -i -u `id -u`:`id -g` -v $(pwd):/data minlag/mermaid-cli:10.6.1 mmdc "$@"
```

And set `ob-mermaid-cli-path` to point to it.